### PR TITLE
fix height on card image

### DIFF
--- a/src/components/NewsCard/index.tsx
+++ b/src/components/NewsCard/index.tsx
@@ -21,7 +21,7 @@ const NewsCard = ({ image, title, description, date, slug }: NewsCardProps) => {
 
   return (
     <div className="w-full min-h-full sm:max-w-sm rounded overflow-hidden shadow-lg bg-white text-left flex flex-col">
-      <img className="w-full h-[300px] object-cover" src={image} alt={title} />
+      <img className="w-full object-cover" src={image} alt={title} />
       <div className="flex flex-col justify-between flex-1 p-4">
         <div>
           <h6 className="text-2xl font-bold leading-[29px] mb-2">{title}</h6>


### PR DESCRIPTION
Please check bugfix for news card, fixed so images aren't cut off (see images cut off vs after removing height of 300px)
![Screenshot 2024-08-28 at 09 45 59](https://github.com/user-attachments/assets/135b3e4d-bbdd-4e8b-b97e-71f5ccf85764)
![Screenshot 2024-08-28 at 09 45 28](https://github.com/user-attachments/assets/ca5b6c28-6ca4-4220-a499-d97c2240e8c9)
